### PR TITLE
Ignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ debugData
 #intellJ
 /.idea/*
 *.iml
+
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
## Problem

If I use python script like `python/Main_PyAIvsPyAI.py`, diff occurs due to `__pycache__`.

## Solution

`.gitignore`